### PR TITLE
Have test_utils test AMBER-to-GROMACS conversion via parmed using energy evaluations

### DIFF
--- a/openmoltools/tests/test_utils.py
+++ b/openmoltools/tests/test_utils.py
@@ -7,6 +7,7 @@ from openmoltools import utils
 import simtk.unit as u
 from simtk.openmm import app
 import simtk.openmm as mm
+import simtk.openmm.openmm as mmmm
 from distutils.spawn import find_executable
 import parmed
 
@@ -65,7 +66,7 @@ def test_parmed_conversion():
         #Set up amber system
         a = parmed.amber.AmberParm( prmtop, inpcrd )
         ambersys = a.createSystem()
-        ambercon = Context( ambersys, VerletIntegrator(0.001))
+        ambercon = mmmm.Context( ambersys, mm.VerletIntegrator(0.001))
         ambercon.setPositions( a.positions )
         #Set up GROMACS system
         g = parmed.load_file( out_top )
@@ -73,7 +74,7 @@ def test_parmed_conversion():
         g.box = gro.box
         g.positions = gro.positions
         gromacssys = g.createSystem()
-        gromacscon = Context( gromacssys, VerletIntegrator(0.001))
+        gromacscon = mmmm.Context( gromacssys, mm.VerletIntegrator(0.001))
         gromacscon.setPositions( g.positions ) 
 
         #Check energies

--- a/openmoltools/tests/test_utils.py
+++ b/openmoltools/tests/test_utils.py
@@ -6,14 +6,10 @@ from mdtraj.testing import eq
 from openmoltools import utils
 import simtk.unit as u
 from simtk.openmm import app
-from simtk.openmm.app import *
 import simtk.openmm as mm
 from distutils.spawn import find_executable
 import parmed
 
-#Extras?
-from simtk.openmm import *; from simtk.openmm.app import *; from simtk.unit import *
-import simtk.unit as u
 
 HAVE_RDKIT = True
 try:
@@ -94,8 +90,6 @@ def test_parmed_conversion():
         if not ok:
             raise(ValueError("AMBER to GROMACS conversion yields energies which are too different.")) 
     
-        #PROBABLY ALSO WANT TO DO THIS IN PBC, MAYBE WITH SOLVENT 
-
 
 @skipIf(SKIP_CHECKMOL, "Skipping testing of checkmol descriptors since checkmol is not found (under that name)." )
 def test_checkmol_descriptors():

--- a/openmoltools/tests/test_utils.py
+++ b/openmoltools/tests/test_utils.py
@@ -78,12 +78,22 @@ def test_parmed_conversion():
         g.positions = gro.positions
         gromacssys = g.createSystem()
         gromacscon = Context( gromacssys, VerletIntegrator(0.001))
-        gromacscon.setPositions( gromacssys.positions ) 
+        gromacscon.setPositions( g.positions ) 
 
         #Check energies
-        print(chem.openmm.utils.energy_decomposition( a, ambercon ))    
-        print(chem.openmm.utils.energy_decomposition( g, gromacscon ))    
-        #NEED TO ADD CODE HERE TO CROSS-COMPARE ENERGIES AND RAISE EXCEPTION IF THEY ARE TOO DIFFERENT
+        a_energies = parmed.openmm.utils.energy_decomposition( a, ambercon )    
+        g_energies = parmed.openmm.utils.energy_decomposition( g, gromacscon )
+        #Check components
+        tolerance = 1e-5
+        ok = True
+        for key in a_energies.keys():
+            diff = np.abs(a_energies[key] - g_energies[key] )
+            if diff/np.abs(a_energies[key]) > tolerance:
+                ok = False
+                print("In testing AMBER to GROMACS conversion, %s energy differs by %.5g, which is more than a fraction %.2g of the total, so conversion appears not to be working properly." % ( key, diff, tolerance) )
+        if not ok:
+            raise(ValueError("AMBER to GROMACS conversion yields energies which are too different.")) 
+    
         #PROBABLY ALSO WANT TO DO THIS IN PBC, MAYBE WITH SOLVENT 
 
 

--- a/openmoltools/utils.py
+++ b/openmoltools/utils.py
@@ -485,7 +485,7 @@ def get_checkmol_descriptors( molecule_filename, executable_name = 'checkmol' ):
  
     return descriptors
 
-def amber_to_gromacs( molecule_name, in_prmtop, in_crd, out_top = None, out_gro = None): 
+def amber_to_gromacs( molecule_name, in_prmtop, in_crd, out_top = None, out_gro = None, precision = None): 
     """Use ParmEd to convert AMBER prmtop and crd files to GROMACS format.
 
     Requires
@@ -505,6 +505,8 @@ def amber_to_gromacs( molecule_name, in_prmtop, in_crd, out_top = None, out_gro 
         String specifying path to GROMACS-format topology file which will be written out. If none is provided, created based on molecule_name.
     out_gro : str, optional, default = None
         String specifying path to GROMACS-format coordinate (.gro) file which will be written out. If none is provided, created based on molecule_name.
+    precision : int, optional, default = None
+        If not none, set the precision of the coordinates in the written .gro file to the specified number of decimal places.
 
     Returns
     -------
@@ -523,6 +525,10 @@ def amber_to_gromacs( molecule_name, in_prmtop, in_crd, out_top = None, out_gro 
     if out_gro is None:
         out_gro = "%s.gro" % molecule_name
 
+    #Check precision
+    if precision is not None:
+        assert type(precision) is IntType, "Precision %s is not an integer." % precision
+
     #Import ParmEd
     import parmed
 
@@ -532,7 +538,10 @@ def amber_to_gromacs( molecule_name, in_prmtop, in_crd, out_top = None, out_gro 
     gromacs_topology = parmed.gromacs.GromacsTopologyFile.from_structure( structure )
     #Write
     parmed.gromacs.GromacsTopologyFile.write( gromacs_topology, out_top )
-    parmed.gromacs.GromacsGroFile.write( gromacs_topology, out_gro )
+    if precision == None:    
+        parmed.gromacs.GromacsGroFile.write( gromacs_topology, out_gro )
+    else:
+        parmed.gromacs.GromacsGroFile.write( gromacs_topology, out_gro, precision = precision )
 
     return out_top, out_gro
 

--- a/openmoltools/utils.py
+++ b/openmoltools/utils.py
@@ -527,6 +527,7 @@ def amber_to_gromacs( molecule_name, in_prmtop, in_crd, out_top = None, out_gro 
 
     #Check precision
     if precision is not None:
+        from types import *
         assert type(precision) is IntType, "Precision %s is not an integer." % precision
 
     #Import ParmEd


### PR DESCRIPTION
@nividic - can you do a quick sanity check of this for me? Note you'll need the openmm development version for the latest ParmEd to work (`conda install openmm-dev') and you'll need the latest parmed. 

Also, let me know whether or not I'll cause problems for you if I go ahead and merge. If you're working on something I don't want to make it more difficult for you.